### PR TITLE
fix: problem with losing focus when resizing the window

### DIFF
--- a/commands/generate-report/ui.tsx
+++ b/commands/generate-report/ui.tsx
@@ -112,7 +112,7 @@ function Plugin() {
 function ResizeHandle() {
   return <div className="resize-handle"
     onPointerDown={ev => {
-      ev.preventDefault();
+      ev.stopPropagation();
       let down = { x: ev.clientX, y: ev.clientY };
       let downSize = { width: window.innerWidth, height: window.innerHeight };
       let move_ = (ev: PointerEvent) => {


### PR DESCRIPTION
A quick fix for a problem where resizing the window wasn't working properly. Related to https://github.com/romannurik/Figma-Contrast/issues/15

Before:
![before](https://github.com/romannurik/Figma-Contrast/assets/13913581/e4deb96c-6bd0-41d0-b1e0-770fa0f3bbc6)

After:
![after](https://github.com/romannurik/Figma-Contrast/assets/13913581/c742e1c3-b44c-40de-b967-f23a889392a3)
